### PR TITLE
Change badge to use badgen.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Hyper-Orama
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://flat.badgen.net/github/contributors/cwlowder/hyper-orama)](#contributors)
 
 A screen recorder for the hyper terminal. It publishes all captured sessions to [now.sh](https://zeit.co/now)
 


### PR DESCRIPTION
This changes the badge from shields to badge.net (hosted on ZEIT Now)