### PR TITLE
Fixed issue where plugin does not load on a production version of hyper

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,12 +50,9 @@ exports.decorateTerms = (Terms, { React }) => {
         );
         if (canvasCollection.length >= 3) {
           const canvases = new Array();
-          document.body.removeEventListener(
-            'DOMSubtreeModified',
-            canvasListener,
-          );
+
           for (let canvas of canvasCollection) canvases.push(canvas);
-          this.setState({ ...this.state, canvases });
+          this.setState({ canvases });
         }
       };
       // Manually fire listener for soft resets


### PR DESCRIPTION
Fixes #54 
The issue has to do with hyper not liking the ... operator. Also, my version of hyper had 4 canvases, which failed due to us only reading in the first 3 canvases. I think we should look into a version of canvas recording that is more adaptable to any number of canvases.