### PR TITLE
Develop/fix frame branding

### DIFF
--- a/frame-markup.html
+++ b/frame-markup.html
@@ -1,0 +1,55 @@
+<style>
+  .orama-window {
+    position: absolute;
+    margin: 0 auto;
+    display: block;
+    height: calc(var(--orama-window-height) + var(--orama-title-size));
+    width: var(--orama-window-width);
+    bottom: 0;
+    right: 0;
+    left: 0;
+    top: calc(50% - (var(--orama-title-size) / 2));
+    background-color: var(--orama-window-color);
+    overflow: hidden;
+    transform: translateY(-50%);
+    border-radius: var(--orama-title-radius);
+  }
+
+  .orama-title {
+    position: absolute;
+    width: 100%;
+    height: var(--orama-title-size);
+    background-color: var(--orama-window-color);
+  }
+
+  .orama-title div {
+    position: relative;
+    display: inline-block;
+    width: var(--orama-button-size);
+    height: var(--orama-button-size);
+    margin-right: calc(var(--orama-button-size) / 3);
+    top: 50%;
+    transform: translate(calc(var(--orama-button-size) * 1.3), -50%);
+    border-radius: 100%;
+  }
+
+  .orama-title div:nth-child(1) {
+    background-color: var(--orama-close-color);
+  }
+
+  .orama-title div:nth-child(2) {
+    background-color: var(--orama-max-color);
+  }
+
+  .orama-title div:nth-child(3) {
+    background-color: var(--orama-min-color);
+  }
+</style>
+
+<div class="orama-window">
+  <div class="orama-title">
+    <div></div>
+    <div></div>
+    <div></div>
+  </div>
+</div>

--- a/hyper-logo.svg
+++ b/hyper-logo.svg
@@ -1,0 +1,1 @@
+<svg width="19" height="14" viewBox="0 0 19 14" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M18.3495 11.6883H10.3652V13.2466H18.3495V11.6883Z" fill="#FFFFFF"></path><path fill-rule="evenodd" clip-rule="evenodd" d="M7.93028 7.65027L4.65013 5.9115L7.02913 0L0 6.34889L3.08847 8.44274L0.90032 14L7.93028 7.65027Z" fill="#FFFFFF"></path></svg>

--- a/recording.js
+++ b/recording.js
@@ -35,16 +35,23 @@ function save(fileName, data) {
  * @param {Number} width The width of the canvas to frame
  * @param {Number} height The height of the canvas to frame
  * @param {Number} padding The border padding
+ * @param {Number} frameSize Size of title bar of the frame
+ * @param {Number} frameRadius Radius (in pixels) of the frame corners
  */
-function generateFrame(width, height, padding) {
-  padding;
-  // Create Frame
-  const baseCanvas = document.createElement('canvas');
-  baseCanvas.width = width + padding * 2;
-  baseCanvas.height = height + padding * 2;
+function generateFrame(width, height, padding, frameSize, frameRadius) {
+  const { backgroundColor } = window.store.getState().ui;
 
-  const { backgroundColor, foregroundColor } = window.store.getState().ui;
+  /* Import frame markup and hyper logo */
+  const frameMarkup = fs.readFileSync(
+    path.join(__dirname, 'frame-markup.html'),
+    'utf-8',
+  );
+  const hyperLogoSVG = fs.readFileSync(
+    path.join(__dirname, 'hyper-logo.svg'),
+    'utf-8',
+  );
 
+  /* Create Frame & Mount to DOM */
   const frame = document.createElement('div');
   frame.id = 'orama-frame';
   frame.style = `
@@ -57,82 +64,68 @@ function generateFrame(width, height, padding) {
   `;
   frame.innerHTML = `
     <style>
-      .orama-window {
-        position: absolute;
-        margin: 0 auto;
-        z-index: 0;
-        display: block;
-        height: ${height + 40}px;
-        width: ${width}px;
-        bottom: 0;
-        right: 0;
-        left: 0;
-        top: calc(50% - 20px);
-        overflow: hidden;
-        transform: translateY(-50%);
-        background-color: ${backgroundColor};
-        color: ${foregroundColor};
-        -webkit-box-shadow: 0px 5px 41px -4px rgba(0,0,0,0.75);
-        -moz-box-shadow: 0px 5px 41px -4px rgba(0,0,0,0.75);
-        box-shadow: 0px 5px 41px -4px rgba(0,0,0,0.75);
-        border-radius: 8px;
-      }
-      .orama-title {
-        position: absolute;
-        display: block;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 40px;
-        background-color: ${backgroundColor};
-        padding: 10px;
-      }
-      .orama-dot {
-        position: absolute;
-        left: 0;
-        display: inline-block;
-        width: 20px;
-        height: 20px;
-        border-radius: 100%;
-        background-color: white;
-      }
-      .orama-close {
-        left: 10px;
-        background-color: #ff704c;
-      }
-      .orama-max {
-        left: 40px;
-        background-color: #fff94c;
-      }
-      .orama-min {
-        left: 70px;
-        background-color: #4dff35;
+      :root {
+          --orama-size: ${frameSize}px;
+          --orama-button-size: calc(var(--orama-size) / 3.5);
+          --orama-title-size: var(--orama-size);
+          --orama-window-height: ${height}px;
+          --orama-window-width: ${width}px;
+          --orama-title-radius: ${frameRadius}px;
+          --orama-window-color: ${backgroundColor};
+          --orama-close-color: rgb(255, 95, 86);
+          --orama-max-color: rgb(255, 189, 46);
+          --orama-min-color: rgb(39, 201, 63);
       }
     </style>
-    <div class="orama-window">
-      <div class="orama-title">
-        <div class="orama-dot orama-close"></div>
-        <div class="orama-dot orama-max"></div>
-        <div class="orama-dot orama-min"></div>
-      </div>
-    </div>
-  `;
+    ${frameMarkup}`;
   document.body.appendChild(frame);
 
-  /* Paint baseCanvas */
+  // Create Canvas for drawing
+  const baseCanvas = document.createElement('canvas');
+  baseCanvas.height = height + frameSize + padding * 2;
+  baseCanvas.width = width + padding * 2;
+
+  /* Create shadow behind terminal window */
+  const baseCtx = baseCanvas.getContext('2d');
+  baseCtx.fillStyle = 'white';
+  baseCtx.fillRect(0, 0, baseCanvas.width, baseCanvas.height);
+  baseCtx.shadowColor = 'rgba(0, 0, 0, 0.25)';
+  baseCtx.shadowBlur = width / 10;
+  baseCtx.fillStyle = backgroundColor;
+  baseCtx.fillRect(padding, padding + frameSize, width, height - frameRadius);
+
+  /* Paint Frame onto Canvas */
   return html2canvas(document.getElementById('orama-frame'), {
-    canvas: baseCanvas,
-    height: height + padding * 2,
+    backgroundColor: null,
+    height: height + frameSize + padding * 2,
     width: width + padding * 2,
-    scale: 1,
+    allowTaint: true,
     logging: false,
-  }).then(canvas => {
-    const context = canvas.getContext('2d');
-    context.shadowColor = 'black';
-    context.shadowBlur = width / 10;
-    context.fillStyle = backgroundColor;
-    context.fillRect(padding, padding, width, height);
-    return canvas;
+    scale: 1,
+  }).then(htmlCanvas => {
+    /* Draw frame onto base canvas */
+    baseCtx.drawImage(htmlCanvas, 0, frameSize);
+    /* Return promise to canvas with Hyper logo painted */
+    return new Promise((resolve, reject) => {
+      const hyperLogo = new Image();
+      hyperLogo.onload = function() {
+        const [logo_w, logo_h] = [frameSize / 2.5, (frameSize * 14) / 47];
+        const [logo_x, logo_y] = [
+          width / 2 + padding - logo_w / 2,
+          padding + frameSize / 2 - logo_h / 2,
+        ];
+        baseCtx.shadowBlur = 0;
+        baseCtx.drawImage(hyperLogo, logo_x, logo_y, logo_w, logo_h);
+        resolve(baseCanvas);
+      };
+      hyperLogo.onerror = function() {
+        reject(undefined);
+      };
+      hyperLogo.src = `data:image/svg+xml,${encodeURI(hyperLogoSVG).replace(
+        /#/g,
+        '%23',
+      )}`;
+    });
   });
 }
 
@@ -152,75 +145,85 @@ exports.startRecording = function(canvases, fileName) {
     )[param];
   };
 
+  /* Determine video information */
+  const fps = 10;
   const height = getMax('height');
   const width = getMax('width');
+
+  /* Setup recording frame */
+  const { fontSize } = window.store.getState().ui;
+  const frameSize = fontSize * 6;
+  const frameRadius = fontSize / 1.5;
   const framePadding = 150;
 
-  /* Grab tracks from canvases */
-  const chunks = new Array();
-  const fps = 10;
-  generateFrame(width, height, framePadding - 50).then(frameCanvas => {
-    const frameStream = frameCanvas.captureStream(fps);
-    const textStream = (
-      _getCanvas(canvases, 'xterm-text-layer') || _getCanvas(canvases, '')
-    ).captureStream(fps);
-    const cursorStream = _getCanvas(
-      canvases,
-      'xterm-cursor-layer',
-    ).captureStream(fps);
+  generateFrame(width, height, framePadding - 50, frameSize, frameRadius).then(
+    frameCanvas => {
+      const frameStream = frameCanvas.captureStream(fps);
+      const textStream = (
+        _getCanvas(canvases, 'xterm-text-layer') || _getCanvas(canvases, '')
+      ).captureStream(fps);
+      const cursorStream = _getCanvas(
+        canvases,
+        'xterm-cursor-layer',
+      ).captureStream(fps);
 
-    /* Merge tracks into a single stream */
-    let stream;
-    const merger = new VideoStreamMerger({
-      width: width + framePadding * 2,
-      height: height + framePadding * 2,
-      fps,
-      clearRect: false,
-    });
-    merger.addStream(frameStream, {
-      x: 0,
-      y: 0,
-      width: width + framePadding * 2,
-      height: height + framePadding * 2,
-      mute: true,
-    });
-    merger.addStream(textStream, {
-      x: framePadding,
-      y: framePadding,
-      width,
-      height,
-      mute: true,
-    });
-    merger.addStream(cursorStream, {
-      x: framePadding,
-      y: framePadding,
-      width,
-      height,
-      mute: true,
-    });
+      /* Merge tracks into a single stream */
+      let stream;
+      const merger = new VideoStreamMerger({
+        width: width + framePadding * 2,
+        height: height + frameSize + framePadding * 2,
+        fps,
+        clearRect: false,
+      });
+      merger.addStream(frameStream, {
+        x: 0,
+        y: 0,
+        width: width + framePadding * 2,
+        height: height + frameSize + framePadding * 2,
+        mute: true,
+      });
+      merger.addStream(textStream, {
+        x: framePadding,
+        y: framePadding + frameSize / 1.25,
+        width,
+        height,
+        mute: true,
+      });
+      merger.addStream(cursorStream, {
+        x: framePadding,
+        y: framePadding + frameSize / 1.25,
+        width,
+        height,
+        mute: true,
+      });
 
-    merger.start();
-    stream = merger.result;
-    let mimeType = 'video/webm';
-    if (MediaRecorder.isTypeSupported('video/mp4')) {
-      mimeType = 'video/mp4';
-    }
-    record = new MediaRecorder(stream, { mimeType });
-    record.start();
+      /* Begin the video streams */
+      merger.start();
+      stream = merger.result;
+      let mimeType = 'video/webm';
+      if (MediaRecorder.isTypeSupported('video/mp4')) {
+        mimeType = 'video/mp4';
+      }
+      record = new MediaRecorder(stream, { mimeType });
+      record.start();
 
-    record.ondataavailable = chunk => {
-      chunks.push(chunk.data);
-    };
+      /* Handle data from streams */
+      const chunks = new Array();
+      record.ondataavailable = chunk => {
+        chunks.push(chunk.data);
+      };
 
-    record.onstop = () => {
-      merger.destroy();
-      const blob = new Blob(chunks, { type: mimeType });
-      var fullName = `${fileName}.${mimeTypes.extension(mimeType)}`;
-      save(fullName, blob);
-      saveCallback(fullName);
-      saveCallback = null;
-    };
-  });
+      /* Teardown */
+      record.onstop = () => {
+        merger.destroy();
+        const blob = new Blob(chunks, { type: mimeType });
+        var fullName = `${fileName}.${mimeTypes.extension(mimeType)}`;
+        save(fullName, blob);
+        saveCallback(fullName);
+        saveCallback = null;
+      };
+    },
+  );
 };
 
 exports.stopRecording = function(callback) {


### PR DESCRIPTION
Fixes #57. Adds Hyper branding to the recording frame by using correct colors and including the Hyper Logo. List of modifications:

 - Extracted HTML markup for frame into own file for ability to hotswap frames/themes later.
 - Made Frame responsive to current terminal font size (larger font size in Preferences -> larger frame size)
 - Maintain centering of window in logical view of video independent of frame size (larger frame pushes content down)
 - Corrected shadow being drawn after frame painting.
 - Moved variable declarations closer to lines of usage in startRecording

![example](https://user-images.githubusercontent.com/35539750/53923994-d7412980-403f-11e9-9cd4-4051ae880b6e.gif)

Please check out the changes and let me know if anything's not behaving as it should :)