### PR TITLE
Fix Mac path to now executable 

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,14 +85,7 @@ exports.decorateTerms = (Terms, { React }) => {
 
       const pathToTmp = path.join(__dirname, '.tmp');
       var child = spawn(
-        path.join(
-          __dirname,
-          'node_modules',
-          'now',
-          'download',
-          'dist',
-          isWin ? 'now.cmd' : 'now',
-        ),
+        path.join(__dirname, 'node_modules', '.bin', isWin ? 'now.cmd' : 'now'),
         [pathToTmp],
       );
       let worked = false;

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const ncp = require('copy-paste');
 const recording = require('./recording');
 const del = require('del');
 
+const isWin = process.platform === 'win32';
+
 exports.reduceUI = (state, action) => {
   switch (action.type) {
     case 'CONFIG_LOAD':
@@ -83,7 +85,14 @@ exports.decorateTerms = (Terms, { React }) => {
 
       const pathToTmp = path.join(__dirname, '.tmp');
       var child = spawn(
-        path.join(__dirname, 'node_modules', 'now', 'download', 'dist', 'now'),
+        path.join(
+          __dirname,
+          'node_modules',
+          'now',
+          'download',
+          'dist',
+          isWin ? 'now.cmd' : 'now',
+        ),
         [pathToTmp],
       );
       let worked = false;

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ exports.decorateTerms = (Terms, { React }) => {
     // Upload the video using now
     // Pass in the fileName with extension
     _uploadVideo(fileName) {
-      const dir = path.resolve(__dirname, './.tmp');
+      const dir = path.join(__dirname, '.tmp');
 
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir);
@@ -81,9 +81,9 @@ exports.decorateTerms = (Terms, { React }) => {
         'utf8',
       );
 
-      const pathToTmp = path.resolve(__dirname, './.tmp/');
+      const pathToTmp = path.join(__dirname, '.tmp');
       var child = spawn(
-        path.resolve(__dirname, './node_modules/now/download/dist/now'),
+        path.join(__dirname, 'node_modules', 'now', 'download', 'dist', 'now'),
         [pathToTmp],
       );
       let worked = false;
@@ -109,7 +109,7 @@ exports.decorateTerms = (Terms, { React }) => {
     }
 
     _notifyNowLoggedout(fileName) {
-      const dir = path.resolve(__dirname, './.tmp');
+      const dir = path.join(__dirname, '.tmp');
       this.setState({ isLoading: false });
       window.store.dispatch(
         // sents a redux action, to send out noification


### PR DESCRIPTION
#50 

- Switched from using `path.resolve()` to `path.join()` 
- Using path to `now.cmd` on windows only.