### PR TITLE
Updating to handle error case

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,10 @@ exports.decorateTerms = (Terms, { React }) => {
         this._notifyVideoUploaded(`${data}/${fileName}`);
       });
 
+      child.on('error', err => {
+        console.error(err); // eslint-disable-line no-console
+      });
+
       child.on('close', () => {
         if (worked) del(pathToTmp, { force: true });
         // deletes tmp folder after upload


### PR DESCRIPTION
fixes #56 
Will print error to console when the path to `now` does not exist, instead of silently failing